### PR TITLE
Fix the invalid argument issue for `LightboxSpatieMediaLibraryImageEntry`

### DIFF
--- a/src/Infolists/LightboxSpatieMediaLibraryImageEntry.php
+++ b/src/Infolists/LightboxSpatieMediaLibraryImageEntry.php
@@ -35,7 +35,7 @@ class LightboxSpatieMediaLibraryImageEntry extends \Filament\Infolists\Component
     protected function makeLightboxEntryFromMedia(Media $media): LightboxImageEntry
     {
         $entry = LightboxImageEntry::make($media->uuid)
-            ->label(false)
+            ->label(null)
             ->slideGallery($this->getStatePath());
 
         if ($media->hasGeneratedConversion($this->getConversion())) {


### PR DESCRIPTION
Laravel Version: 10.35.0
Filament Version: 3.1.15

When using the `LightboxSpatieMediaLibraryImageEntry` in Infolist, it throws an error because the`label` method from `Filament\Infolists\Components\Component` only accepts `Illuminate\Contracts\Support\Htmlable`, `Closure`, `null`, or `string`.

This pull request simply changes `false` to `null`.