### PR TITLE
Enhancement: Support for Private Visibility in URLs

### DIFF
--- a/src/Infolists/LightboxSpatieMediaLibraryImageEntry.php
+++ b/src/Infolists/LightboxSpatieMediaLibraryImageEntry.php
@@ -39,13 +39,27 @@ class LightboxSpatieMediaLibraryImageEntry extends \Filament\Infolists\Component
             ->hiddenLabel(true)
             ->slideGallery($this->getStatePath());
 
-        if ($media->hasGeneratedConversion($this->getConversion())) {
-            $entry->state($media->getFullUrl($this->getConversion()));
-        } else {
-            $entry->state($media->getFullUrl());
+        if ($this->getVisibility() === 'private') {
+            try {
+                if ($media->hasGeneratedConversion($this->getConversion())) {
+                    $entry->state($media->getTemporaryUrl(now()->addMinutes(5), $this->getConversion()));
+                } else {
+                    $entry->state($media->getTemporaryUrl(now()->addMinutes(5)));
+                }
+                $entry->href($media->getTemporaryUrl(now()->addMinutes(5)));
+            } catch (Throwable $exception) {
+                // This driver does not support creating temporary URLs.
+            }
         }
-
-        $entry->href($media->getFullUrl());
+        else
+        {
+            if ($media->hasGeneratedConversion($this->getConversion())) {
+                $entry->state($media->getFullUrl($this->getConversion()));
+            } else {
+                $entry->state($media->getFullUrl());
+            }
+            $entry->href($media->getFullUrl());
+        }
 
         if ($this->isCircular()) {
             $entry->circular();


### PR DESCRIPTION
This update introduces the ability for users to specify the visibility of their media items as private through the `->visibility('private')` method. Prior to this change, setting the visibility to private was not fully supported, leading to a scenario where images could not be accessed and would result in a 404 error. This was due to the system's not generating the necessary temporary URLs for private media.

With this enhancement, when the visibility is set to 'private', the system now correctly generates secure, temporary URLs, ensuring private images are accessible and displayed as intended.

Example usage:

```php
LightboxSpatieMediaLibraryImageEntry::make('foo')
    ->collection('images')
    ->conversion('thumb')
    ->visibility('private') // Now properly supported
    ->circular()
    ->label('Bar');
```

This feature enhances the library's flexibility, allowing for more secure media management by ensuring private images remain private, accessible only through generated temporary URLs.

This change was for `LightboxSpatieMediaLibraryImageEntry` wrap.