### PR TITLE
filament v4 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,10 +22,10 @@
         }
     ],
     "require": {
-        "php": "^8.1",
-        "filament/filament": "^3.0|^4.0",
+        "php": "^8.2",
+        "filament/filament": "^4.0",
         "spatie/laravel-package-tools": "^1.15.0",
-        "illuminate/contracts": "^10.0|^11.0|^12.0"
+        "illuminate/contracts": "^11.0|^12.0"
     },
     "require-dev": {
         "laravel/pint": "^1.0",

--- a/src/Infolists/LightboxSpatieMediaLibraryImageEntry.php
+++ b/src/Infolists/LightboxSpatieMediaLibraryImageEntry.php
@@ -2,7 +2,7 @@
 
 namespace Njxqlus\Filament\Components\Infolists;
 
-use Filament\Infolists\ComponentContainer;
+use Filament\Schemas\Schema;
 use Njxqlus\Filament\Components\GLightBox;
 use Njxqlus\Filament\Components\HasGLightBox;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
@@ -13,7 +13,7 @@ class LightboxSpatieMediaLibraryImageEntry extends \Filament\Infolists\Component
 
     protected string $view = 'filament-lightbox::infolists.lightbox-spatie-media-library-image-entry';
 
-    public function getChildComponentContainer($key = null): ComponentContainer
+    public function getChildComponentContainer($key = null): Schema
     {
         if (filled($key)) {
             return $this->getChildComponentContainers()[$key];


### PR DESCRIPTION
Fixes compatibility with filament v4.

Unfortunatly because v4 ditched the ComponentContainer class, there is easy way to make the package available both for v3 and v4.

I think the package needs a major version number bump to split v3 and v4.

Also update composer dep requirments to match fillament min requriments.