### PR TITLE
fix: exception when rendering the infolist component

### DIFF
--- a/src/Infolists/LightboxComponentContainer.php
+++ b/src/Infolists/LightboxComponentContainer.php
@@ -2,9 +2,9 @@
 
 namespace Njxqlus\Filament\Components\Infolists;
 
-use Filament\Infolists\ComponentContainer;
+use Filament\Schemas\Schema;
 
-class LightboxComponentContainer extends ComponentContainer
+class LightboxComponentContainer extends Schema
 {
     protected string $view = 'filament-lightbox::infolists.lightbox-component-container';
 }


### PR DESCRIPTION
As discussed in https://github.com/njxqlus/filament-lightbox/issues/32 there is an exception when using the infolist component. This PR aims to fix that issue.